### PR TITLE
Fix compile time API changes for Postgresql 9.5

### DIFF
--- a/src/client/utils.c
+++ b/src/client/utils.c
@@ -559,7 +559,11 @@ get_current_database_owner_name()
     else
         return NULL;
 
-    return GetUserNameFromId(owner);
+    return GetUserNameFromId(owner
+#if PG_MAJOR_VERSION >= 905
+        , false
+#endif
+        );
 }
 
 /*
@@ -658,7 +662,11 @@ execute_custom_script(const char *filename, const char *schemaName)
                                     t_sql,
                                     CStringGetTextDatum("@current_user@"),
                                     CStringGetTextDatum(
-                                        GetUserNameFromId(GetUserId())));
+                                        GetUserNameFromId(GetUserId()
+#if PG_MAJOR_VERSION >= 905
+                                          , false
+#endif
+                                          )));
 
         /*
          * substitute the database owner for occurrences of @database_owner@

--- a/src/client/utils.c
+++ b/src/client/utils.c
@@ -596,6 +596,9 @@ execute_custom_script(const char *filename, const char *schemaName)
 #if PG_MAJOR_VERSION > 901
                                  , 0
 #endif
+#if PG_MAJOR_VERSION >= 905
+                                 , false
+#endif
             );
     if (log_min_messages < WARNING)
         (void) set_config_option("log_min_messages", "warning",
@@ -603,6 +606,9 @@ execute_custom_script(const char *filename, const char *schemaName)
                                  GUC_ACTION_SAVE, true
 #if PG_MAJOR_VERSION > 901
                                  , 0
+#endif
+#if PG_MAJOR_VERSION >= 905
+                                 , false
 #endif
             );
 
@@ -624,6 +630,9 @@ execute_custom_script(const char *filename, const char *schemaName)
                              GUC_ACTION_SAVE, true
 #if PG_MAJOR_VERSION > 901
                              , 0
+#endif
+#if PG_MAJOR_VERSION >= 905
+                             , false
 #endif
         );
 


### PR DESCRIPTION
There might also be an issue with `read_binary_file`, which is now a private function in 9.5. Still testing. 
